### PR TITLE
embed gmnotes fixes

### DIFF
--- a/scripts/embed-gmnotes.py
+++ b/scripts/embed-gmnotes.py
@@ -63,8 +63,8 @@ def main():
                 # Delete the .gmnotes file
                 os.remove(gmnotes_path)
 
-                # Add the content as a new "GMNotes" field
-                json_data["GMNotes"] = gmnotes_content
+                # Add the content as a new "GMNotes" field, removing newline from the end of the string
+                json_data["GMNotes"] = gmnotes_content.rstrip('\n')
 
                 # Delete the old "GMNotes_path" field
                 del json_data["GMNotes_path"]

--- a/scripts/embed-gmnotes.py
+++ b/scripts/embed-gmnotes.py
@@ -74,7 +74,7 @@ def main():
 
                 # Write the updated JSON back to the file
                 with open(file_path, "w", encoding="utf-8") as f:
-                    json.dump(sorted_json_data, f, indent=2)
+                    json.dump(sorted_json_data, f, indent=2, ensure_ascii=False)
                     f.write("\n")  # Add an empty line at the end
 
                 print(f"{json_data["Nickname"]}: Embedded GMNotes")


### PR DESCRIPTION
1. Minor fix to preserve non-ascii characters (to avoid names like Ablenkungsman\u00f6ver)
2. Remove \n from the end of the GMNotes object, otherwise JSON in GMNotes is invalid
Before:
`"{\n  \"id\": \"60522\"\n}\n"`
After:
`"{\n  \"id\": \"60522\"\n}"`
